### PR TITLE
MHTTP-1: bugfix for sonar analytics

### DIFF
--- a/RichardSzalay.MockHttp/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp/MockHttpMessageHandler.cs
@@ -5,10 +5,10 @@ namespace RichardSzalay.MockHttp;
 
 public class MockHttpMessageHandler : HttpMessageHandler
 {
-    private Queue<IMockedRequest> requestExpectations = new Queue<IMockedRequest>();
-    private List<IMockedRequest> backendDefinitions = new List<IMockedRequest>();
-    private Dictionary<IMockedRequest, int> matchCounts = new Dictionary<IMockedRequest, int>();
-    private object lockObject = new object();
+    private Queue<IMockedRequest> requestExpectations = new();
+    private List<IMockedRequest> backendDefinitions = new();
+    private Dictionary<IMockedRequest, int> matchCounts = new();
+    private readonly object lockObject = new();
 
     private int outstandingRequests = 0;
 


### PR DESCRIPTION
Do not lock on writable field 'lockObject', use a readonly field instead.